### PR TITLE
Update README Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This tool will use the cluster-api/pkg/deployer code to generate the cluster-api
     cd $GOPATH/src/sigs.k8s.io
     git clone https://github.com/oneilcin/cluster-api-tools
     cd cluster-api-tools
-    go run genClusterApiServerYaml.go > clusterapi-apiserver.yaml  (use any output file name)
+    go run genClusterApiServerYaml.go > clusterapi-apiserver.yaml
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 This tool will use the cluster-api/pkg/deployer code to generate the cluster-api apiserver deployment manifest.
 
 ## Run the tool to generate the clusterapi-apiserver.yaml
+
     cd $GOPATH/src/sigs.k8s.io
     git clone https://github.com/oneilcin/cluster-api-tools
     cd cluster-api-tools

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## genClusterApiServerYaml
 
-This tool will use the cluster-api/pkg/deployer code to generate the cluster-api apiserver deployment manifest. 
+This tool will use the cluster-api/pkg/deployer code to generate the cluster-api apiserver deployment manifest.
 
-## Run the tool to generate the clusterapi-apiserver.yaml 
+## Run the tool to generate the clusterapi-apiserver.yaml
     cd $GOPATH/src/sigs.k8s.io
     git clone https://github.com/oneilcin/cluster-api-tools
     cd cluster-api-tools
@@ -15,8 +15,10 @@ This tool will use the cluster-api/pkg/deployer code to generate the cluster-api
 First deploy the cluster-api server, and then deploy the chosen provider components.
 
     minikube start --bootstrapper=kubeadm
-    kubectl create -f clusterapi-apiserver.yaml
-    kubectl create -f provider-components.yaml   (this includes the provider machine and cluster controllers)
+    kubectl create -f clusterapi-apiserver.yaml -f provider-components.yaml
+    # wait for the apiserver pod to be ready
+    kubectl get pods -w
+    kubectl create -f cluster.yaml -f machines.yaml --validate=false
 
 Instructions to generate the provider-components.yaml are [here](https://github.com/samsung-cnct/cluster-api-provider-ssh/blob/master/clusterctl/examples/ssh/README.md)
 


### PR DESCRIPTION
- organize the `kubectl` commands for efficiency
- mirror the YAML files created on the `clusterctl` instructions

w/incidental trailing whitespace removal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oneilcin/cluster-api-tools/1)
<!-- Reviewable:end -->
